### PR TITLE
Update float.Parse() in ReadGesture() to InvariantCulture

### DIFF
--- a/Assets/PDollar/Scripts/PDollarGestureRecognizer/GestureIO.cs
+++ b/Assets/PDollar/Scripts/PDollarGestureRecognizer/GestureIO.cs
@@ -80,8 +80,8 @@ namespace PDollarGestureRecognizer
                             break;
                         case "Point":
                             points.Add(new Point(
-                                float.Parse(xmlReader["X"]),
-                                float.Parse(xmlReader["Y"]),
+                                float.Parse(xmlReader["X"].Replace(',', '.'), CultureInfo.InvariantCulture),
+                                float.Parse(xmlReader["Y"].Replace(',', '.'), CultureInfo.InvariantCulture),
                                 currentStrokeIndex
                             ));
                             break;


### PR DESCRIPTION
If you read gesture .xml files that have "." instead of "," as decimal separators it can parse the data incorrectly. This happened to me because I created the files using another tool, and it took me a while to find the problem. However it doesn't happen if you use the WriteGesture() function in the repo.
I solved it by replacing "," with ".", and then using InvariantCulture in the Parse function. Here a related stackoveflow thread: https://stackoverflow.com/questions/11560465/parse-strings-to-double-with-comma-and-point
I hope it can help!